### PR TITLE
added socket path for database conn on ubuntu.

### DIFF
--- a/php/php.ini
+++ b/php/php.ini
@@ -3,3 +3,4 @@ post_max_size = 100M
 upload_max_filesize = 100M
 variables_order = EGPCS
 max_execution_time = 3000
+pdo_mysql.default_socket=/var/run/mysqld/mysqld.sock


### PR DESCRIPTION
Adding `pdo_mysql.default_socket=/var/run/mysqld/mysqld.sock` to the php.ini file to test unixe_socket connection in ubuntu.